### PR TITLE
Enable selected acs tests to be skipped

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,9 @@ if(DEFINED SUITE_TEST_RANGE)
     add_definitions(-DSUITE_TEST_RANGE_MAX="${SUITE_TEST_RANGE_MAX}")
 endif()
 
+if(DEFINED SUITE_EXCLUDED)
+    add_definitions(-DSUITE_EXCLUDED="${SUITE_EXCLUDED}")
+endif()
 
 
 # Setup toolchain parameters for compilation and link

--- a/plat/common/inc/pal_libc.h
+++ b/plat/common/inc/pal_libc.h
@@ -48,5 +48,9 @@ void *pal_memset(void *dst, int val, size_t count);
 **/
 void *pal_memcpy(void *dst, const void *src, size_t len);
 
+int pal_strlen(char *string);
 
+char *pal_strtok(char *string,char *delimiter);
+
+char* pal_strcpy(char* destination, const char* source);
 #endif

--- a/plat/common/src/pal_libc.c
+++ b/plat/common/src/pal_libc.c
@@ -71,3 +71,82 @@ int memcmp(void *s1, void *s2, size_t len)
 
     return 0;
 }
+
+// Reference: https://velog.io/@bakukun/%EA%B8%B0%EB%B3%B8-%EB%9D%BC%EC%9D%B4%EB%B8%8C%EB%9F%AC%EB%A6%AC%EB%A1%9C-C%EC%96%B8%EC%96%B4-strtok%ED%95%A8%EC%88%98-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0
+char *pal_strtok(char *str,char *deli){	
+	int i;
+	int deli_len = pal_strlen(deli);
+	static char* tmp = NULL;
+	
+	if(str != NULL && !tmp){
+		tmp = str;
+	}
+	
+	if(str == NULL && !tmp){
+		return NULL;
+	}
+	
+	char* idx = tmp;
+	while(true){
+		for(i = 0; i < deli_len; i++) { 
+            if(*idx == deli[i]) { 
+                idx++; 
+                break;
+            }
+		}
+		
+		if(i == deli_len) {
+            tmp = idx;
+            break;
+        }
+    }
+    				
+    if(*tmp == '\0') {
+        tmp = NULL;
+        return tmp;
+    }
+ 
+    while(*tmp != '\0') {
+        for(i = 0; i < deli_len; i++) {
+            if(*tmp == deli[i]) {
+                *tmp = '\0';
+                break;
+            }
+        }
+ 
+        tmp++;
+        if (i < deli_len){
+            break;
+		}
+    }
+    return idx;
+}
+
+int pal_strlen(char *str){
+    int cnt=0;
+    while(str[cnt]!='\0'){
+        ++cnt;
+    }
+    return cnt;
+}
+
+//Reference: https://www.techiedelight.com/ko/implement-strcpy-function-c/
+char* pal_strcpy(char* destination, const char* source)
+{
+    if (destination == NULL) {
+        return NULL;
+    }
+ 
+    char *ptr = destination;
+ 
+    while (*source != '\0')
+    {
+        *destination = *source;
+        destination++;
+        source++;
+    }
+ 
+    *destination = '\0';
+ 
+    return ptr;
+}

--- a/val/host/src/val_host_framework.c
+++ b/val/host/src/val_host_framework.c
@@ -295,6 +295,22 @@ static void val_host_test_dispatch(bool primary_cpu_boot)
     test_fptr_t       fn_ptr;
     val_test_info_ts       test_info = {0};
     val_regre_report_ts    regre_report = {0};
+#if defined(SUITE_EXCLUDED)
+    char str[] = SUITE_EXCLUDED;
+    char delimeter[] = ",";
+    char *result = NULL;
+    char excluded_tests[60][80];
+    uint32_t k = 0;
+    uint32_t total_excluded = 0;
+	    
+    result = pal_strtok(str, delimeter);
+
+    while (result != NULL) {
+        pal_strcpy(excluded_tests[k++], result);
+        result = pal_strtok(NULL, delimeter);
+    }
+    total_excluded = k;
+#endif
 
     if (primary_cpu_boot == true)
     {
@@ -375,6 +391,18 @@ static void val_host_test_dispatch(bool primary_cpu_boot)
         /* Iterate over test_list[] to run test one by one */
         for (i = test_num_start ; i <= test_num_end; i++)
         {
+#if defined(SUITE_EXCLUDED)
+            bool skip = false;
+            for (k = 0; k < total_excluded; k++) {
+                if (val_strcmp((char *)test_list[i].test_name, excluded_tests[k]) == 0) {
+                    skip = true;
+                }
+            }
+
+            if (skip == true) {
+                continue;
+            }
+#endif
             fn_ptr = (test_fptr_t)(test_list[i].host_fn);
 
             if (fn_ptr == NULL)


### PR DESCRIPTION
This PR is a pre-requisite for skipping user-provided acs tests. `strtok`, `strlen`, and `strcpy` are added manually, as there is a lack of standard library support.
