### PR TITLE
[Workaround] clear the last page of initrd and kernel

### DIFF
--- a/arm/kvm.c
+++ b/arm/kvm.c
@@ -146,7 +146,7 @@ bool kvm__arch_load_kernel_image(struct kvm *kvm, int fd_kernel, int fd_initrd,
 	void *pos, *kernel_end, *limit;
 	unsigned long guest_addr;
 	ssize_t file_size;
-    uintptr_t initrd_end;
+	uintptr_t initrd_end;
 
 	/*
 	 * Linux requires the initrd and dtb to be mapped inside lowmem,
@@ -169,12 +169,12 @@ bool kvm__arch_load_kernel_image(struct kvm *kvm, int fd_kernel, int fd_initrd,
 	pr_debug("Loaded kernel to 0x%llx (%llu bytes)",
 		 kvm->arch.kern_guest_start, kvm->arch.kern_size);
 
-    if (!IS_ALIGNED((uintptr_t)kernel_end, PAGE_SIZE)) {
-        explicit_bzero(kernel_end,
-		    (size_t)(ALIGN((uintptr_t)kernel_end, PAGE_SIZE) - (uintptr_t)kernel_end));
-    }
-	if (kvm->cfg.arch.is_realm)
+	if (kvm->cfg.arch.is_realm) {
+		if (!IS_ALIGNED((uintptr_t)kernel_end, PAGE_SIZE))
+			explicit_bzero(kernel_end,
+				(size_t)(ALIGN((uintptr_t)kernel_end, PAGE_SIZE) - (uintptr_t)kernel_end));
 		kvm_arm_realm_populate_kernel(kvm);
+	}
 
 	/*
 	 * Now load backwards from the end of memory so the kernel
@@ -220,13 +220,13 @@ bool kvm__arch_load_kernel_image(struct kvm *kvm, int fd_kernel, int fd_initrd,
 		pr_debug("Loaded initrd to 0x%llx (%llu bytes)",
 			 kvm->arch.initrd_guest_start, kvm->arch.initrd_size);
 
-        if (kvm->cfg.arch.is_realm) {
-            initrd_end = (uintptr_t)pos + (uintptr_t)file_size;
+		if (kvm->cfg.arch.is_realm) {
+			initrd_end = (uintptr_t)pos + (uintptr_t)file_size;
 				if (!IS_ALIGNED(initrd_end, PAGE_SIZE))
 					explicit_bzero((void *)initrd_end,
-					               (size_t)(ALIGN(initrd_end, PAGE_SIZE) - initrd_end));
+						(size_t)(ALIGN(initrd_end, PAGE_SIZE) - initrd_end));
 			kvm_arm_realm_populate_initrd(kvm);
-        }
+		}
 	} else {
 		kvm->arch.initrd_size = 0;
 	}

--- a/arm/kvm.c
+++ b/arm/kvm.c
@@ -146,6 +146,7 @@ bool kvm__arch_load_kernel_image(struct kvm *kvm, int fd_kernel, int fd_initrd,
 	void *pos, *kernel_end, *limit;
 	unsigned long guest_addr;
 	ssize_t file_size;
+    uintptr_t initrd_end;
 
 	/*
 	 * Linux requires the initrd and dtb to be mapped inside lowmem,
@@ -168,6 +169,10 @@ bool kvm__arch_load_kernel_image(struct kvm *kvm, int fd_kernel, int fd_initrd,
 	pr_debug("Loaded kernel to 0x%llx (%llu bytes)",
 		 kvm->arch.kern_guest_start, kvm->arch.kern_size);
 
+    if (!IS_ALIGNED((uintptr_t)kernel_end, PAGE_SIZE)) {
+        explicit_bzero(kernel_end,
+		    (size_t)(ALIGN((uintptr_t)kernel_end, PAGE_SIZE) - (uintptr_t)kernel_end));
+    }
 	if (kvm->cfg.arch.is_realm)
 		kvm_arm_realm_populate_kernel(kvm);
 
@@ -215,8 +220,13 @@ bool kvm__arch_load_kernel_image(struct kvm *kvm, int fd_kernel, int fd_initrd,
 		pr_debug("Loaded initrd to 0x%llx (%llu bytes)",
 			 kvm->arch.initrd_guest_start, kvm->arch.initrd_size);
 
-		if (kvm->cfg.arch.is_realm)
+        if (kvm->cfg.arch.is_realm) {
+            initrd_end = (uintptr_t)pos + (uintptr_t)file_size;
+				if (!IS_ALIGNED(initrd_end, PAGE_SIZE))
+					explicit_bzero((void *)initrd_end,
+					               (size_t)(ALIGN(initrd_end, PAGE_SIZE) - initrd_end));
 			kvm_arm_realm_populate_initrd(kvm);
+        }
 	} else {
 		kvm->arch.initrd_size = 0;
 	}


### PR DESCRIPTION
There is something wrong with the p9 shared fs implementation, which leads to the overwirte of the last page with random junk. This leads to unreliable measurements.